### PR TITLE
platform/mellanox: mlxreg-hotplug: Add support for handling interrupt storm

### DIFF
--- a/drivers/platform/mellanox/mlxreg-hotplug.c
+++ b/drivers/platform/mellanox/mlxreg-hotplug.c
@@ -11,6 +11,7 @@
 #include <linux/hwmon-sysfs.h>
 #include <linux/i2c.h>
 #include <linux/interrupt.h>
+#include <linux/jiffies.h>
 #include <linux/module.h>
 #include <linux/of_device.h>
 #include <linux/platform_data/mlxreg.h>
@@ -30,6 +31,11 @@
 
 #define MLXREG_HOTPLUG_ATTRS_MAX	128
 #define MLXREG_HOTPLUG_NOT_ASSERT	3
+
+/* Interrupt storm definitios */
+#define MLXREG_HOTPLUG_WM_COUNTER 100
+/* Time window in milliseconds */
+#define MLXREG_HOTPLUG_WM_WINDOW 3000
 
 /**
  * struct mlxreg_hotplug_priv_data - platform private data:
@@ -364,7 +370,7 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
 			   struct mlxreg_core_item *item)
 {
 	struct mlxreg_core_data *data;
-	unsigned long asserted;
+	unsigned long asserted, wmark_low_ts_window;
 	u32 regval, bit;
 	int ret;
 
@@ -400,11 +406,34 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
 	for_each_set_bit(bit, &asserted, 8) {
 		int pos;
 
+		/* Skip already marked storming bit. */
+		if (item->storming_bits & BIT(bit))
+			continue;
+
 		pos = mlxreg_hotplug_item_label_index_get(item->mask, bit);
 		if (pos < 0)
 			goto out;
 
 		data = item->data + pos;
+
+		/* Interrupt storm handling logic. */
+		if (data->wmark_low_cntr == 0)
+			data->wmark_low_ts = jiffies;
+
+		if (data->wmark_low_cntr == MLXREG_HOTPLUG_WM_COUNTER - 1) {
+			data->wmark_high_ts = jiffies;
+			wmark_low_ts_window = data->wmark_low_ts +
+					      msecs_to_jiffies(MLXREG_HOTPLUG_WM_WINDOW);
+			if (time_after(data->wmark_high_ts, wmark_low_ts_window)) {
+				dev_err(priv->dev, "Storming bit %d (label: %s) - interrupt masked permanently. Replace broken HW.",
+					bit, data->label);
+				/* Mark bit as storming. */
+				item->storming_bits |= BIT(bit);
+			} else {
+				data->wmark_low_cntr = 0;
+			}
+		}
+		data->wmark_low_cntr++;
 		if (regval & BIT(bit)) {
 			if (item->inversed)
 				mlxreg_hotplug_device_destroy(priv, data, item->kind);
@@ -424,9 +453,9 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
 	if (ret)
 		goto out;
 
-	/* Unmask event. */
+	/* Unmask event, exclude storming bits. */
 	ret = regmap_write(priv->regmap, item->reg + MLXREG_HOTPLUG_MASK_OFF,
-			   item->mask);
+			   item->mask & ~item->storming_bits);
 
  out:
 	if (ret)

--- a/include/linux/platform_data/mlxreg.h
+++ b/include/linux/platform_data/mlxreg.h
@@ -133,6 +133,9 @@ struct mlxreg_hotplug_device {
  * @regnum: number of registers occupied by multi-register attribute;
  * @slot: slot number, at which device is located;
  * @secured: if set indicates that entry access is secured;
+ * @wmark_low_cntr: interrupt storm counter;
+ * @wmark_low_ts: interrupt storm low bound timestamp;
+ * @wmark_high_ts: interrupt storm high bound timestamp;
  */
 struct mlxreg_core_data {
 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
@@ -155,6 +158,9 @@ struct mlxreg_core_data {
 	u8 regnum;
 	u8 slot;
 	u8 secured;
+	unsigned int wmark_low_cntr;
+	unsigned long wmark_low_ts;
+	unsigned long wmark_high_ts;
 };
 
 /**
@@ -173,6 +179,7 @@ struct mlxreg_core_data {
  * @ind: element's index inside the group;
  * @inversed: if 0: 0 for signal status is OK, if 1 - 1 is OK;
  * @health: true if device has health indication, false in other case;
+ * @storming_bits: interrupt storming bits mask;
  */
 struct mlxreg_core_item {
 	struct mlxreg_core_data *data;
@@ -188,6 +195,7 @@ struct mlxreg_core_item {
 	u8 ind;
 	u8 inversed;
 	u8 health;
+	u32 storming_bits;
 };
 
 /**


### PR DESCRIPTION
In case of broken hardware, it is possible that broken device will
flood interrupt handler with false events.
For example, if fan or power supply has damaged presence pin, it will
cause permanent generation of presence in / presence out events.
As a result, interrupt handler will consume a lot of CPU resources and
will keep raising "UDEV" events to the user space.

At the same device with damaged pin still will be capable to provide
telemetry date.

Provide mechanism allowing to detect device causing interrupt flooding
and mask interrupt for this specific device, to isolate from interrupt
handling flow.

Use the following criteria: if the specific interrupt was generated 'N'
time during 'T' seconds, such device is to be considered as broken and
will be closed for getting interrupts.

User will be notified through the log error and will be instructed to
replace broken device.